### PR TITLE
Setup GitHub Pages with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - gh-actions-setup
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Build Website
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - gh-actions-setup
+      - main
 
 jobs:
   deploy:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,14 +9,14 @@ const config = {
   title: 'COVID-19 Credentials with a Federated PKI',
   tagline: 'Trusted exchange of World Health Organization Digital Documentatin of COVID-10 Certificates.',
   url: 'https://your-docusaurus-test-site.com',
-  baseUrl: '/',
+  baseUrl: '/cc-pki/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'who', // Usually your GitHub org/user name.
+  organizationName: 'dvci', // Usually your GitHub org/user name.
   projectName: 'cc-pki', // Usually your repo name.
 
   // Even if you don't use internalization, you can use this field to set useful
@@ -76,7 +76,7 @@ const config = {
             items: [
               {
                 label: 'Guide',
-                to: '/docs/intro',
+                to: '/',
               },
             ],
           },


### PR DESCRIPTION
# Summary

Sets up GitHub Pages using GitHub Actions. The action is configured to redeploy on pushes to the `main` branch.

The site is currently live at https://dvci.github.io/cc-pki/